### PR TITLE
Correctly indent main.go controller imports

### DIFF
--- a/genmain.go
+++ b/genmain.go
@@ -18,8 +18,8 @@ import (
 	"log"
 	"net/http"
 
-    ` + commonVal + `
-    ` + indexVal + `
+	` + commonVal + `
+	` + indexVal + `
 	"github.com/gorilla/mux"
 )
 


### PR DESCRIPTION
Imports for project controllers required a tab character, rather than 4 spaces